### PR TITLE
Revise CoC to be more explicit about unacceptable behavior

### DIFF
--- a/slack-code-of-conduct.md
+++ b/slack-code-of-conduct.md
@@ -1,6 +1,8 @@
 # Elm Slack Community Code of Conduct
 
-Online communities include people from many different backgrounds. The moderators of this community are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
+Online communities include people from many different backgrounds. The moderators of this community are committed to
+providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race,
+religion, sexuality, or similar personal characteristic.
 
 As participants of this community we pledge to:
 
@@ -9,22 +11,33 @@ As participants of this community we pledge to:
 - __Be respectful.__ 
 - __Be considerate.__
 - __Avoid negative behaviour__.
-	- Derailing a conversation: if you want to talk about something else, start a new conversation.
-	- Unconstructive criticism: don't merely decry the current state of affairs; offer suggestions as to how things may be improved.
-	- Snarking (pithy, unproductive, sniping comments)
-	- Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
-	- Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group.
+  - Derailing a conversation: if you want to talk about something else, start a new conversation.
+  - Unconstructive criticism: don't merely decry the current state of affairs; offer suggestions as to how things may be
+    improved.
+  - Snarking (pithy, unproductive, sniping comments)
+  - Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+  - Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile,
+    derogatory or negative slights and insults to a person or group.
 
-Everyone can make a valuable contribution to this community. We may not always agree, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one.
+Everyone can make a valuable contribution to this community. We may not always agree, but disagreement is no excuse for
+poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that
+frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable
+or threatened is not a productive one.
 
-Sometimes misundestandings and conflicts are inevitable, but resits the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it.
+Sometimes misundestandings and conflicts are inevitable, but resits the urge to be defensive or assign blame. Try not to
+take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do
+not rise to it.
 
-We are committed to making participation in this community a harassment-free experience for everyone. As such moderators have the right and responsibility to remove, edit, or reject comments and other assets that are not aligned to this Code of Conduct, 
-or to ban temporarily or permanently any participant for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+We are committed to making participation in this community a harassment-free experience for everyone. As such moderators
+have the right and responsibility to remove, edit, or reject comments and other assets that are not aligned to this Code
+of Conduct, or to ban temporarily or permanently any participant for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
 
 ## Reporting issues
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the community maintainer at s@porto5.com. Do not post about the issue publicly or try to rally sentiment against a particular individual or group. Moderators are obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the community
+maintainer at s@porto5.com. Do not post about the issue publicly or try to rally sentiment against a particular
+individual or group. Moderators are obligated to maintain confidentiality with regard to the reporter of an incident.
 
 ## Acknowledgements
 

--- a/slack-code-of-conduct.md
+++ b/slack-code-of-conduct.md
@@ -1,13 +1,16 @@
 # Elm Slack Community Code of Conduct
 
-Online communities include people from many different backgrounds. The moderators of this community are committed to
-providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race,
-religion, sexuality, or similar personal characteristic. We do not tolerate harassment or abuse in any form.
+The Elm Slack community is a welcoming environment where everyone can seek help and discussion on any Elm-related topic.
+To ensure that our Slack remains as friendly as it currently is, this Code of Conduct documents our rules, values, and
+expectations.
+
+The members and moderators of the Elm Slack community are committed to providing a friendly, safe and welcoming
+environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal
+characteristic. We do not tolerate harassment or abuse in any form.
 
 As participants of this community we pledge to:
 
 - __Be friendly, welcoming and inclusive.__
-  - Do not avoid someone just because they are new to the community.
 - __Be helpful and patient.__
   - Do not _intentionally_ post inaccurate, misleading, or deceptive technical information.
   - Do not ridicule someone's ignorance or misunderstanding.
@@ -23,7 +26,7 @@ As participants of this community we pledge to:
   - Snarking: pithy, insulting, or sniping comments.
   - Discussing potentially offensive or sensitive issues; this frequently leads to unnecessary conflict. There's no
     reason to discuss hot-button political issues in a programming chat room.
-  - Microaggressions: brief and common hostile behaviors that cumulatively communicate that a certain person or group is
+  - Brief and common hostile behaviors that cumulatively communicate that a certain person or group is
     unwelcome.
 
 Everyone can make a valuable contribution to this community. We may not always agree, but disagreement is no excuse for

--- a/slack-code-of-conduct.md
+++ b/slack-code-of-conduct.md
@@ -16,11 +16,12 @@ As participants of this community we pledge to:
   - Do not ridicule someone's ignorance or misunderstanding.
 - __Be respectful and considerate.__
   - People have different levels of experience programming, and with many types of languages. Someone who struggles with
-    Elm might have 15 years of enterprise Java experience. Don't make assumptions about someone's background.
-  - Not everyone speaks English natively. If you can understand the intent, don't remark on the grammar.
+    Elm might have 15 years of enterprise Java experience. Making assumptions about someone's background is usually
+    harmful.
+  - Not everyone speaks English natively. If you can understand the intent, avoid remarking on the grammar.
 - __Avoid negative behaviour.__
   - Derailing a conversation: Chat conversations can move quickly and unpredictably. But, do not actively seek to
-    prevent a conversation from occurring.
+    prevent a conversation from occurring (unless the conversation itself violates this Code).
   - Unconstructive criticism: Do not merely decry the current state of affairs. Offer suggestions as to how things may
     be improved.
   - Snarking: pithy, insulting, or sniping comments.

--- a/slack-code-of-conduct.md
+++ b/slack-code-of-conduct.md
@@ -6,11 +6,11 @@ religion, sexuality, or similar personal characteristic.
 
 As participants of this community we pledge to:
 
-- __Be friendly, welcoming and inclusive.__ 
-- __Be helpful and patient.__ 
-- __Be respectful.__ 
+- __Be friendly, welcoming and inclusive.__
+- __Be helpful and patient.__
+- __Be respectful.__
 - __Be considerate.__
-- __Avoid negative behaviour__.
+- __Avoid negative behaviour.__
   - Derailing a conversation: if you want to talk about something else, start a new conversation.
   - Unconstructive criticism: don't merely decry the current state of affairs; offer suggestions as to how things may be
     improved.
@@ -24,7 +24,7 @@ poor behavior and poor manners. We might all experience some frustration now and
 frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable
 or threatened is not a productive one.
 
-Sometimes misundestandings and conflicts are inevitable, but resits the urge to be defensive or assign blame. Try not to
+Sometimes misunderstandings and conflicts are inevitable, but resist the urge to be defensive or assign blame. Try not to
 take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do
 not rise to it.
 
@@ -36,11 +36,11 @@ threatening, offensive, or harmful.
 ## Reporting issues
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the community
-maintainer at s@porto5.com. Do not post about the issue publicly or try to rally sentiment against a particular
+maintainer at `s@porto5.com`. Do not post about the issue publicly or try to rally sentiment against a particular
 individual or group. Moderators are obligated to maintain confidentiality with regard to the reporter of an incident.
 
 ## Acknowledgements
 
-This Code of Conduct is adapted from 
+This Code of Conduct is adapted from
 - [Contributor Covenant](https://github.com/ContributorCovenant/contributor_covenant)
 - [Go Code of Conduct](https://golang.org/conduct)

--- a/slack-code-of-conduct.md
+++ b/slack-code-of-conduct.md
@@ -2,22 +2,29 @@
 
 Online communities include people from many different backgrounds. The moderators of this community are committed to
 providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race,
-religion, sexuality, or similar personal characteristic.
+religion, sexuality, or similar personal characteristic. We do not tolerate harassment or abuse in any form.
 
 As participants of this community we pledge to:
 
 - __Be friendly, welcoming and inclusive.__
+  - Do not avoid someone just because they are new to the community.
 - __Be helpful and patient.__
-- __Be respectful.__
-- __Be considerate.__
+  - Do not _intentionally_ post inaccurate, misleading, or deceptive technical information.
+  - Do not ridicule someone's ignorance or misunderstanding.
+- __Be respectful and considerate.__
+  - People have different levels of experience programming, and with many types of languages. Someone who struggles with
+    Elm might have 15 years of enterprise Java experience. Don't make assumptions about someone's background.
+  - Not everyone speaks English natively. If you can understand the intent, don't remark on the grammar.
 - __Avoid negative behaviour.__
-  - Derailing a conversation: if you want to talk about something else, start a new conversation.
-  - Unconstructive criticism: don't merely decry the current state of affairs; offer suggestions as to how things may be
-    improved.
-  - Snarking (pithy, unproductive, sniping comments)
-  - Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
-  - Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile,
-    derogatory or negative slights and insults to a person or group.
+  - Derailing a conversation: Chat conversations can move quickly and unpredictably. But, do not actively seek to
+    prevent a conversation from occurring.
+  - Unconstructive criticism: Do not merely decry the current state of affairs. Offer suggestions as to how things may
+    be improved.
+  - Snarking: pithy, insulting, or sniping comments.
+  - Discussing potentially offensive or sensitive issues; this frequently leads to unnecessary conflict. There's no
+    reason to discuss hot-button political issues in a programming chat room.
+  - Microaggressions: brief and common hostile behaviors that cumulatively communicate that a certain person or group is
+    unwelcome.
 
 Everyone can make a valuable contribution to this community. We may not always agree, but disagreement is no excuse for
 poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that
@@ -35,9 +42,10 @@ threatening, offensive, or harmful.
 
 ## Reporting issues
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the community
-maintainer at `s@porto5.com`. Do not post about the issue publicly or try to rally sentiment against a particular
-individual or group. Moderators are obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, threatening, or otherwise unacceptable behavior may be reported by contacting the
+community maintainer at `s@porto5.com`. Do not post about the issue publicly or try to rally sentiment against a
+particular individual or group. Moderators are obligated to maintain confidentiality with regard to the reporter of an
+incident.
 
 ## Acknowledgements
 


### PR DESCRIPTION
This patch is split into three commits. The first two are pretty unexciting.

The third commit revises the actual content of the CoC. My main goals in doing so are:
- Be more explicit, defining words like "friendly", "helpful", and "considerate". Revise the definition of "microagression" to sound reasonable to someone who isn't an activist.
- Remove concern that a reasonable person could accidentally violate a rule
- In addition to stating rules and consequences, state the values of the community, and things to keep in mind when participating

I don't think anything will be particularly controversial but I'm open to splitting this into multiple commits and PRs if necessary.
